### PR TITLE
Add memory fake storage for dice and room repositories

### DIFF
--- a/cmd/rollify/config.go
+++ b/cmd/rollify/config.go
@@ -4,6 +4,11 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
+const (
+	// StorageTypeMemory is the memory storage type.
+	StorageTypeMemory = "memory"
+)
+
 // CmdConfig represents the configuration of the command.
 type CmdConfig struct {
 	Development        bool
@@ -11,6 +16,7 @@ type CmdConfig struct {
 	APIListenAddr      string
 	InternalListenAddr string
 	MetricsPath        string
+	StorageType        string
 }
 
 // NewCmdConfig returns a new command configuration.
@@ -24,6 +30,7 @@ func NewCmdConfig(args []string) (*CmdConfig, error) {
 	app.Flag("api-listen-address", "the address where the HTTP API server will be listening.").Default(":8080").StringVar(&c.APIListenAddr)
 	app.Flag("internal-listen-address", "the address where the HTTP internal data (metrics, pprof...) server will be listening.").Default(":8081").StringVar(&c.InternalListenAddr)
 	app.Flag("metrics-path", "the path where Prometehus metrics will be served.").Default("/metrics").StringVar(&c.MetricsPath)
+	app.Flag("storage-type", "the storage type used on the application.").Default(StorageTypeMemory).EnumVar(&c.StorageType, StorageTypeMemory)
 
 	_, err := app.Parse(args[1:])
 	if err != nil {

--- a/internal/dice/dice_test.go
+++ b/internal/dice/dice_test.go
@@ -156,7 +156,7 @@ func TestServiceCreateDiceRoll(t *testing.T) {
 			expErr: true,
 		},
 
-		"Having a dice roll request and failing the dice roll process, it should fail..": {
+		"Having a dice roll request and failing the dice roll process, it should fail.": {
 			mock: func(roller *dicemock.Roller, repo *dicemock.Repository) {
 				roller.On("Roll", mock.Anything, mock.Anything).Once().Return(fmt.Errorf("wanted error"))
 			},

--- a/internal/room/storage.go
+++ b/internal/room/storage.go
@@ -10,8 +10,8 @@ import (
 // implement to manage rooms in storage.
 type Repository interface {
 	// CreateRoom creates a new room.
-	// If the room doesn't have an ID it returns a errors.KindNotValid error kind.
-	// If the room already exists it returns a errors.KindAlreadyExists error kind.
+	// If the room doesn't have an ID it returns a internalerrors.NotValid error kind.
+	// If the room already exists it returns a internalerrors.AlreadyExists error kind.
 	CreateRoom(ctx context.Context, r model.Room) error
 }
 

--- a/internal/storage/memory/dice.go
+++ b/internal/storage/memory/dice.go
@@ -1,0 +1,59 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rollify/rollify/internal/dice"
+	"github.com/rollify/rollify/internal/internalerrors"
+	"github.com/rollify/rollify/internal/model"
+)
+
+// DiceRepository is a memory based dice repository.
+type DiceRepository struct {
+	mu            sync.Mutex
+	diceRollsByID map[string]model.DiceRoll
+}
+
+// NewDiceRepository returns a new DiceRepository.
+func NewDiceRepository() *DiceRepository {
+	return &DiceRepository{
+		diceRollsByID: map[string]model.DiceRoll{},
+	}
+}
+
+// SetDiceRollsByIDSeed helper function to set the data we want at any point.
+func (r *DiceRepository) SetDiceRollsByIDSeed(data map[string]model.DiceRoll) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.diceRollsByID = data
+}
+
+// DiceRollsByIDSeed helper function to get the data we want at any point.
+func (r *DiceRepository) DiceRollsByIDSeed() map[string]model.DiceRoll {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.diceRollsByID
+}
+
+// CreateDiceRoll satisfies dice.Repository interface.
+func (r *DiceRepository) CreateDiceRoll(ctx context.Context, dr model.DiceRoll) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if dr.ID == "" {
+		return internalerrors.ErrNotValid
+	}
+
+	_, ok := r.diceRollsByID[dr.ID]
+	if ok {
+		return internalerrors.ErrAlreadyExists
+	}
+
+	r.diceRollsByID[dr.ID] = dr
+
+	return nil
+}
+
+// Implementation assertions.
+var _ dice.Repository = &DiceRepository{}

--- a/internal/storage/memory/dice_test.go
+++ b/internal/storage/memory/dice_test.go
@@ -1,0 +1,78 @@
+package memory_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rollify/rollify/internal/internalerrors"
+	"github.com/rollify/rollify/internal/model"
+	"github.com/rollify/rollify/internal/storage/memory"
+)
+
+func TestDiceRepositoryCreateDiceRoll(t *testing.T) {
+	tests := map[string]struct {
+		repo        func() *memory.DiceRepository
+		diceRoll    model.DiceRoll
+		expDiceRoll model.DiceRoll
+		expErr      error
+	}{
+		"Having a dice roll without ID should return a not valid error.": {
+			repo: func() *memory.DiceRepository {
+				return memory.NewDiceRepository()
+			},
+			diceRoll: model.DiceRoll{
+				ID: "",
+			},
+			expErr: internalerrors.ErrNotValid,
+		},
+
+		"Creating a dice roll that already exists should return an error.": {
+			repo: func() *memory.DiceRepository {
+				r := memory.NewDiceRepository()
+				r.SetDiceRollsByIDSeed(map[string]model.DiceRoll{
+					"test-id": model.DiceRoll{
+						ID: "test-id",
+					},
+				})
+				return r
+			},
+			diceRoll: model.DiceRoll{
+				ID: "test-id",
+			},
+			expErr: internalerrors.ErrAlreadyExists,
+		},
+
+		"Creating a dice roll should store the room.": {
+			repo: func() *memory.DiceRepository {
+				return memory.NewDiceRepository()
+			},
+			diceRoll: model.DiceRoll{
+				ID: "test-id",
+			},
+			expDiceRoll: model.DiceRoll{
+				ID: "test-id",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r := test.repo()
+			err := r.CreateDiceRoll(context.TODO(), test.diceRoll)
+
+			if test.expErr != nil && assert.Error(err) {
+				assert.True(errors.Is(err, test.expErr))
+			} else if assert.NoError(err) {
+				// Check the dice roll has been created internally.
+				seed := r.DiceRollsByIDSeed()
+				gotDiceRoll := seed[test.expDiceRoll.ID]
+				assert.Equal(test.expDiceRoll, gotDiceRoll)
+			}
+		})
+	}
+}

--- a/internal/storage/memory/room.go
+++ b/internal/storage/memory/room.go
@@ -1,0 +1,59 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/rollify/rollify/internal/internalerrors"
+	"github.com/rollify/rollify/internal/model"
+	"github.com/rollify/rollify/internal/room"
+)
+
+// RoomRepository is a memory based room repository.
+type RoomRepository struct {
+	mu        sync.Mutex
+	roomsByID map[string]model.Room
+}
+
+// NewRoomRepository returns a new RoomRepository.
+func NewRoomRepository() *RoomRepository {
+	return &RoomRepository{
+		roomsByID: map[string]model.Room{},
+	}
+}
+
+// SetRoomsByIDSeed helper function to set the data we want at any point.
+func (r *RoomRepository) SetRoomsByIDSeed(data map[string]model.Room) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.roomsByID = data
+}
+
+// RoomsByIDSeed helper function to get the data we want at any point.
+func (r *RoomRepository) RoomsByIDSeed() map[string]model.Room {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.roomsByID
+}
+
+// CreateRoom satisfies room.Repository interface.
+func (r *RoomRepository) CreateRoom(ctx context.Context, room model.Room) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if room.ID == "" {
+		return internalerrors.ErrNotValid
+	}
+
+	_, ok := r.roomsByID[room.ID]
+	if ok {
+		return internalerrors.ErrAlreadyExists
+	}
+
+	r.roomsByID[room.ID] = room
+
+	return nil
+}
+
+// Implementation assertions.
+var _ room.Repository = &RoomRepository{}

--- a/internal/storage/memory/room_test.go
+++ b/internal/storage/memory/room_test.go
@@ -1,0 +1,83 @@
+package memory_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/rollify/rollify/internal/internalerrors"
+	"github.com/rollify/rollify/internal/model"
+	"github.com/rollify/rollify/internal/storage/memory"
+)
+
+func TestRoomRepositoryCreateRoom(t *testing.T) {
+	tests := map[string]struct {
+		repo    func() *memory.RoomRepository
+		room    model.Room
+		expRoom model.Room
+		expErr  error
+	}{
+		"Having a room without ID should return a not valid error.": {
+			repo: func() *memory.RoomRepository {
+				return memory.NewRoomRepository()
+			},
+			room: model.Room{
+				ID:   "",
+				Name: "test",
+			},
+			expErr: internalerrors.ErrNotValid,
+		},
+
+		"Creating a room that already exists should return an error.": {
+			repo: func() *memory.RoomRepository {
+				r := memory.NewRoomRepository()
+				r.SetRoomsByIDSeed(map[string]model.Room{
+					"test-id": model.Room{
+						ID:   "test-id",
+						Name: "test",
+					},
+				})
+				return r
+			},
+			room: model.Room{
+				ID:   "test-id",
+				Name: "test",
+			},
+			expErr: internalerrors.ErrAlreadyExists,
+		},
+
+		"Creating a room should store the room.": {
+			repo: func() *memory.RoomRepository {
+				return memory.NewRoomRepository()
+			},
+			room: model.Room{
+				ID:   "test-id",
+				Name: "test",
+			},
+			expRoom: model.Room{
+				ID:   "test-id",
+				Name: "test",
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			r := test.repo()
+			err := r.CreateRoom(context.TODO(), test.room)
+
+			if test.expErr != nil && assert.Error(err) {
+				assert.True(errors.Is(err, test.expErr))
+			} else if assert.NoError(err) {
+				// Check the room has been created internally.
+				seed := r.RoomsByIDSeed()
+				gotRoom := seed[test.expRoom.ID]
+				assert.Equal(test.expRoom, gotRoom)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- closes #3
- closes #10 

This PR adds memory fake repositories for dice and room repositories. Also adds a flag to select the storage type, for now and by default, `memory`