### PR TITLE
Implement memory storage cursor pagination for dice roll listing

### DIFF
--- a/internal/dice/dice.go
+++ b/internal/dice/dice.go
@@ -212,7 +212,12 @@ func (s service) ListDiceRolls(ctx context.Context, r ListDiceRollsRequest) (*Li
 		return nil, fmt.Errorf("%w: %s", internalerrors.ErrNotValid, err)
 	}
 
-	drs, err := s.diceRollRepository.ListDiceRolls(ctx, storage.ListDiceRollsOpts{
+	pageOpts := storage.PaginationOpts{
+		Order: storage.PaginationOrderDesc,
+		Size:  100,
+	}
+
+	drs, err := s.diceRollRepository.ListDiceRolls(ctx, pageOpts, storage.ListDiceRollsOpts{
 		RoomID: r.RoomID,
 		UserID: r.UserID,
 	})

--- a/internal/dice/dice_test.go
+++ b/internal/dice/dice_test.go
@@ -270,7 +270,7 @@ func TestServiceListDiceRolls(t *testing.T) {
 
 		"Having a list dice roll request with an error listing dice rolls, should fail.": {
 			mock: func(diceRollRepo *storagemock.DiceRollRepository, roomRepo *storagemock.RoomRepository) {
-				diceRollRepo.On("ListDiceRolls", mock.Anything, mock.Anything).Once().Return(nil, fmt.Errorf("wanted error"))
+				diceRollRepo.On("ListDiceRolls", mock.Anything, mock.Anything, mock.Anything).Once().Return(nil, fmt.Errorf("wanted error"))
 			},
 			req: func() dice.ListDiceRollsRequest {
 				return dice.ListDiceRollsRequest{
@@ -293,7 +293,7 @@ func TestServiceListDiceRolls(t *testing.T) {
 						{ID: "dr2"},
 					},
 				}
-				diceRollRepo.On("ListDiceRolls", mock.Anything, expOpts).Once().Return(dr, nil)
+				diceRollRepo.On("ListDiceRolls", mock.Anything, mock.Anything, expOpts).Once().Return(dr, nil)
 			},
 			req: func() dice.ListDiceRollsRequest {
 				return dice.ListDiceRollsRequest{

--- a/internal/storage/memory/dice.go
+++ b/internal/storage/memory/dice.go
@@ -2,7 +2,10 @@ package memory
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 
 	"github.com/rollify/rollify/internal/internalerrors"
@@ -65,28 +68,107 @@ func (r *DiceRollRepository) CreateDiceRoll(ctx context.Context, dr model.DiceRo
 	return nil
 }
 
+type cursor struct {
+	Serial int `json:"serial"`
+}
+
 // ListDiceRolls satisfies storage.DiceRollRepository interface.
-func (r *DiceRollRepository) ListDiceRolls(ctx context.Context, opts storage.ListDiceRollsOpts) (*storage.DiceRollList, error) {
-	if opts.RoomID == "" {
+func (r *DiceRollRepository) ListDiceRolls(ctx context.Context, pageOpts storage.PaginationOpts, filterOpts storage.ListDiceRollsOpts) (*storage.DiceRollList, error) {
+	if filterOpts.RoomID == "" {
 		return nil, internalerrors.ErrNotValid
 	}
 
+	// Filter.
 	var items []*model.DiceRoll
-
 	// If no user means all room.
-	if opts.UserID == "" {
-		items = r.DiceRollsByRoom[opts.RoomID]
+	if filterOpts.UserID == "" {
+
+		items = r.DiceRollsByRoom[filterOpts.RoomID]
 	} else {
-		items = r.DiceRollsByRoomAndUser[opts.RoomID+opts.UserID]
+		items = r.DiceRollsByRoomAndUser[filterOpts.RoomID+filterOpts.UserID]
+	}
+
+	// Get serial from cursor.
+	// We use -1 because to search the starting point of the cursor, is the next one of the received serial,
+	// if we don't receive cursor, that would be 0 cursor, and the next one is 1, so we would loose the first
+	// user.
+	userCursor := cursor{Serial: -1}
+	if pageOpts.Cursor != "" {
+		c, err := base64.StdEncoding.DecodeString(pageOpts.Cursor)
+		if err != nil {
+			return nil, fmt.Errorf("could not decode base64 cursor: %w", err)
+		}
+		err = json.Unmarshal(c, &userCursor)
+		if err != nil {
+			return nil, fmt.Errorf("could not unmarshal json cursor: %w", err)
+		}
+	}
+
+	// Sort and get starting point based on cursor.
+	// By default uses desc order (newest first).
+	startIndex := 0
+	if pageOpts.Order == storage.PaginationOrderAsc {
+		sort.SliceStable(items, func(i, j int) bool { return items[i].Serial < items[j].Serial })
+		// Search for the starting point of the list based on the cursor.
+		// (Not optimized, don't need).
+		for i, dr := range items {
+			if int(dr.Serial) > userCursor.Serial {
+				startIndex = i
+				break
+			}
+		}
+	} else {
+		sort.SliceStable(items, func(i, j int) bool { return items[i].Serial > items[j].Serial })
+		// Filter (Not optimized, don't need).
+		for i, dr := range items {
+			if int(dr.Serial) < userCursor.Serial {
+				startIndex = i
+				break
+			}
+		}
+	}
+
+	// Filter the list from the starting point that we got with the cursor and
+	// then cut wiht the size limit.
+	filteredItems := items[startIndex:]
+	hasNext := false
+	if len(filteredItems) > int(pageOpts.Size) {
+		hasNext = true
+		filteredItems = filteredItems[:pageOpts.Size]
+	}
+
+	// Create our cursors.
+	fistCursor := ""
+	lastCursor := ""
+	if len(filteredItems) > 0 {
+		c := cursor{Serial: int(filteredItems[0].Serial)}
+		jc, err := json.Marshal(c)
+		if err != nil {
+			return nil, fmt.Errorf("could not marshal cursor: %w", err)
+		}
+		fistCursor = base64.StdEncoding.EncodeToString([]byte(jc))
+
+		c = cursor{Serial: int(filteredItems[len(filteredItems)-1].Serial)}
+		jc, err = json.Marshal(c)
+		if err != nil {
+			return nil, fmt.Errorf("could not marshal cursor: %w", err)
+		}
+		lastCursor = base64.StdEncoding.EncodeToString([]byte(jc))
 	}
 
 	resultItems := make([]model.DiceRoll, 0, len(items))
-	for _, v := range items {
+	for _, v := range filteredItems {
 		resultItems = append(resultItems, *v)
 	}
 
 	return &storage.DiceRollList{
 		Items: resultItems,
+		Cursors: storage.Cursors{
+			FirstCursor: fistCursor,
+			LastCursor:  lastCursor,
+			HasPrevious: startIndex != 0, // If we are not the first means that we have previous.
+			HasNext:     hasNext,
+		},
 	}, nil
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -6,9 +6,38 @@ import (
 	"github.com/rollify/rollify/internal/model"
 )
 
+// Cursors has the information regarding the listing cursors of a
+// paginated list.
+type Cursors struct {
+	FirstCursor string
+	LastCursor  string
+	HasNext     bool
+	HasPrevious bool
+}
+
+// PaginationOrder is the order used to list.
+type PaginationOrder int
+
+const (
+	// PaginationOrderDefault is the default order used to list pages.
+	PaginationOrderDefault PaginationOrder = iota
+	// PaginationOrderAsc is the ascendant order used to list pages.
+	PaginationOrderAsc
+	// PaginationOrderDesc is the descendant order used to list pages.
+	PaginationOrderDesc
+)
+
+// PaginationOpts are the options used to paginate.
+type PaginationOpts struct {
+	Cursor string
+	Size   uint
+	Order  PaginationOrder
+}
+
 // DiceRollList is a list of dice rolls.
 type DiceRollList struct {
 	Items []model.DiceRoll
+	Cursors
 }
 
 // ListDiceRollsOpts are the options used by the storage to list dice rolls.
@@ -26,7 +55,7 @@ type DiceRollRepository interface {
 	CreateDiceRoll(ctx context.Context, dr model.DiceRoll) error
 	// ListDiceRolls lists dice rolls.
 	// If the dice roomID option is empty it returns a internalerrors.NotValid error kind.
-	ListDiceRolls(ctx context.Context, opts ListDiceRollsOpts) (*DiceRollList, error)
+	ListDiceRolls(ctx context.Context, pageOpts PaginationOpts, filterOpts ListDiceRollsOpts) (*DiceRollList, error)
 }
 
 //go:generate mockery -case underscore -output storagemock -outpkg storagemock -name DiceRollRepository

--- a/internal/storage/storagemock/dice_roll_repository.go
+++ b/internal/storage/storagemock/dice_roll_repository.go
@@ -30,13 +30,13 @@ func (_m *DiceRollRepository) CreateDiceRoll(ctx context.Context, dr model.DiceR
 	return r0
 }
 
-// ListDiceRolls provides a mock function with given fields: ctx, opts
-func (_m *DiceRollRepository) ListDiceRolls(ctx context.Context, opts storage.ListDiceRollsOpts) (*storage.DiceRollList, error) {
-	ret := _m.Called(ctx, opts)
+// ListDiceRolls provides a mock function with given fields: ctx, pageOpts, filterOpts
+func (_m *DiceRollRepository) ListDiceRolls(ctx context.Context, pageOpts storage.PaginationOpts, filterOpts storage.ListDiceRollsOpts) (*storage.DiceRollList, error) {
+	ret := _m.Called(ctx, pageOpts, filterOpts)
 
 	var r0 *storage.DiceRollList
-	if rf, ok := ret.Get(0).(func(context.Context, storage.ListDiceRollsOpts) *storage.DiceRollList); ok {
-		r0 = rf(ctx, opts)
+	if rf, ok := ret.Get(0).(func(context.Context, storage.PaginationOpts, storage.ListDiceRollsOpts) *storage.DiceRollList); ok {
+		r0 = rf(ctx, pageOpts, filterOpts)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*storage.DiceRollList)
@@ -44,8 +44,8 @@ func (_m *DiceRollRepository) ListDiceRolls(ctx context.Context, opts storage.Li
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, storage.ListDiceRollsOpts) error); ok {
-		r1 = rf(ctx, opts)
+	if rf, ok := ret.Get(1).(func(context.Context, storage.PaginationOpts, storage.ListDiceRollsOpts) error); ok {
+		r1 = rf(ctx, pageOpts, filterOpts)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
Contributes to #20 

This PR implements pagination for Listing dice rolls, the pagination is based on cursors, it adds previous and next. the implementation has been made on the memory implementation.