### PR TITLE
Add metrics to the event subscriber

### DIFF
--- a/cmd/rollify/main.go
+++ b/cmd/rollify/main.go
@@ -127,6 +127,7 @@ func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 	// Events.
 	hub := eventmemory.NewHub(logger)
 	notifier := event.NewMeasuredNotifier("memory", metricsRecorder, hub)
+	subscriber := event.NewMeasuredSubscriber("memory", metricsRecorder, hub)
 
 	// Create app services.
 	diceAppService, err := dice.NewService(dice.ServiceConfig{
@@ -135,7 +136,7 @@ func Run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
 		UserRepository:     userRepo,
 		Roller:             roller,
 		EventNotifier:      notifier,
-		EventSubscriber:    hub,
+		EventSubscriber:    subscriber,
 		Logger:             logger,
 	})
 	if err != nil {

--- a/internal/dice/dice.go
+++ b/internal/dice/dice.go
@@ -320,14 +320,14 @@ func (s service) SubscribeDiceRollCreated(ctx context.Context, r SubscribeDiceRo
 
 	// Create a subscription ID and subscribe.
 	subscriptionID := s.idGen()
-	err = s.eventSubscriber.SubscribeDiceRollCreated(subscriptionID, r.RoomID, r.EventHandler)
+	err = s.eventSubscriber.SubscribeDiceRollCreated(ctx, subscriptionID, r.RoomID, r.EventHandler)
 	if err != nil {
 		return nil, fmt.Errorf("could not subscribe to diceRollCreated events: %w", err)
 	}
 
 	return &SubscribeDiceRollCreatedResponse{
 		UnsubscribeFunc: func() error {
-			return s.eventSubscriber.UnsubscribeDiceRollCreated(subscriptionID, r.RoomID)
+			return s.eventSubscriber.UnsubscribeDiceRollCreated(ctx, subscriptionID, r.RoomID)
 		},
 	}, nil
 

--- a/internal/dice/dice_test.go
+++ b/internal/dice/dice_test.go
@@ -562,7 +562,7 @@ func TestSubscribeDiceRollCreated(t *testing.T) {
 		"Having a subscription request with an error while subscribing to the bus to the event bus.": {
 			mock: func(roomRepo *storagemock.RoomRepository, eventSubscriber *eventmock.Subscriber) {
 				roomRepo.On("RoomExists", mock.Anything, "room-id").Once().Return(true, nil)
-				eventSubscriber.On("SubscribeDiceRollCreated", "test", "room-id", mock.Anything).Once().Return(errors.New("wanted error"))
+				eventSubscriber.On("SubscribeDiceRollCreated", mock.Anything, "test", "room-id", mock.Anything).Once().Return(errors.New("wanted error"))
 			},
 			req: func() dice.SubscribeDiceRollCreatedRequest {
 				return dice.SubscribeDiceRollCreatedRequest{
@@ -576,8 +576,8 @@ func TestSubscribeDiceRollCreated(t *testing.T) {
 		"Having a subscription request should subscribe to the event bus, and the user should (be able to) call unsubscribe.": {
 			mock: func(roomRepo *storagemock.RoomRepository, eventSubscriber *eventmock.Subscriber) {
 				roomRepo.On("RoomExists", mock.Anything, "room-id").Once().Return(true, nil)
-				eventSubscriber.On("SubscribeDiceRollCreated", "test", "room-id", mock.Anything).Once().Return(nil)
-				eventSubscriber.On("UnsubscribeDiceRollCreated", "test", "room-id").Once().Return(nil)
+				eventSubscriber.On("SubscribeDiceRollCreated", mock.Anything, "test", "room-id", mock.Anything).Once().Return(nil)
+				eventSubscriber.On("UnsubscribeDiceRollCreated", mock.Anything, "test", "room-id").Once().Return(nil)
 			},
 			req: func() dice.SubscribeDiceRollCreatedRequest {
 				return dice.SubscribeDiceRollCreatedRequest{

--- a/internal/event/event.go
+++ b/internal/event/event.go
@@ -15,8 +15,8 @@ type Notifier interface {
 
 // Subscriber knows how to subscribe to events.
 type Subscriber interface {
-	SubscribeDiceRollCreated(subscribeID, roomID string, h func(context.Context, model.EventDiceRollCreated) error) error
-	UnsubscribeDiceRollCreated(subscribeID, roomID string) error
+	SubscribeDiceRollCreated(ctx context.Context, subscribeID, roomID string, h func(context.Context, model.EventDiceRollCreated) error) error
+	UnsubscribeDiceRollCreated(ctx context.Context, subscribeID, roomID string) error
 }
 
 //go:generate mockery -case underscore -output eventmock -outpkg eventmock -name Subscriber

--- a/internal/event/eventmock/subscriber.go
+++ b/internal/event/eventmock/subscriber.go
@@ -15,13 +15,13 @@ type Subscriber struct {
 	mock.Mock
 }
 
-// SubscribeDiceRollCreated provides a mock function with given fields: subscribeID, roomID, h
-func (_m *Subscriber) SubscribeDiceRollCreated(subscribeID string, roomID string, h func(context.Context, model.EventDiceRollCreated) error) error {
-	ret := _m.Called(subscribeID, roomID, h)
+// SubscribeDiceRollCreated provides a mock function with given fields: ctx, subscribeID, roomID, h
+func (_m *Subscriber) SubscribeDiceRollCreated(ctx context.Context, subscribeID string, roomID string, h func(context.Context, model.EventDiceRollCreated) error) error {
+	ret := _m.Called(ctx, subscribeID, roomID, h)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, func(context.Context, model.EventDiceRollCreated) error) error); ok {
-		r0 = rf(subscribeID, roomID, h)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, func(context.Context, model.EventDiceRollCreated) error) error); ok {
+		r0 = rf(ctx, subscribeID, roomID, h)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -29,13 +29,13 @@ func (_m *Subscriber) SubscribeDiceRollCreated(subscribeID string, roomID string
 	return r0
 }
 
-// UnsubscribeDiceRollCreated provides a mock function with given fields: subscribeID, roomID
-func (_m *Subscriber) UnsubscribeDiceRollCreated(subscribeID string, roomID string) error {
-	ret := _m.Called(subscribeID, roomID)
+// UnsubscribeDiceRollCreated provides a mock function with given fields: ctx, subscribeID, roomID
+func (_m *Subscriber) UnsubscribeDiceRollCreated(ctx context.Context, subscribeID string, roomID string) error {
+	ret := _m.Called(ctx, subscribeID, roomID)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string) error); ok {
-		r0 = rf(subscribeID, roomID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, subscribeID, roomID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/event/memory/memory.go
+++ b/internal/event/memory/memory.go
@@ -59,7 +59,7 @@ func (h *Hub) NotifyDiceRollCreated(ctx context.Context, e model.EventDiceRollCr
 }
 
 // SubscribeDiceRollCreated satisfies event.Subscriber interface.
-func (h *Hub) SubscribeDiceRollCreated(subscribeID, roomID string, handler func(context.Context, model.EventDiceRollCreated) error) error {
+func (h *Hub) SubscribeDiceRollCreated(ctx context.Context, subscribeID, roomID string, handler func(context.Context, model.EventDiceRollCreated) error) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	logger := h.logger.WithKV(log.KV{"event": "DiceRollCreated"})
@@ -77,7 +77,7 @@ func (h *Hub) SubscribeDiceRollCreated(subscribeID, roomID string, handler func(
 }
 
 // UnsubscribeDiceRollCreated satisfies event.Subscriber interface.
-func (h *Hub) UnsubscribeDiceRollCreated(subscribeID, roomID string) error {
+func (h *Hub) UnsubscribeDiceRollCreated(ctx context.Context, subscribeID, roomID string) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	logger := h.logger.WithKV(log.KV{"event": "DiceRollCreated"})

--- a/internal/event/memory/memory_test.go
+++ b/internal/event/memory/memory_test.go
@@ -101,7 +101,7 @@ func TestHubDiceRollCreatedEventsFlow(t *testing.T) {
 
 			// Subscribe with our check.
 			gotEvents := []model.EventDiceRollCreated{}
-			err := hub.SubscribeDiceRollCreated(test.id, test.roomID, func(_ context.Context, e model.EventDiceRollCreated) error {
+			err := hub.SubscribeDiceRollCreated(context.TODO(), test.id, test.roomID, func(_ context.Context, e model.EventDiceRollCreated) error {
 				gotEvents = append(gotEvents, e)
 				return nil
 			})
@@ -109,7 +109,7 @@ func TestHubDiceRollCreatedEventsFlow(t *testing.T) {
 
 			// In case we want to unsubscribe after subscription.
 			if test.unsubscribe {
-				err := hub.UnsubscribeDiceRollCreated(test.id, test.roomID)
+				err := hub.UnsubscribeDiceRollCreated(context.TODO(), test.id, test.roomID)
 				require.NoError(err)
 			}
 

--- a/internal/metrics/prometheus/prometheus_test.go
+++ b/internal/metrics/prometheus/prometheus_test.go
@@ -393,6 +393,126 @@ func TestRecorder(t *testing.T) {
 				`rollify_notifier_operation_duration_seconds_count{notifier_type="t2",op="op2",success="false"} 1`,
 			},
 		},
+
+		"Measure subscriber subscribe duration.": {
+			measure: func(r metrics.Recorder) {
+				r.MeasureSubscriberSubscribeOpDuration(context.TODO(), "t1", "op1", true, 55*time.Millisecond)
+				r.MeasureSubscriberSubscribeOpDuration(context.TODO(), "t1", "op1", true, 55*time.Millisecond)
+				r.MeasureSubscriberSubscribeOpDuration(context.TODO(), "t1", "op1", true, 6*time.Second)
+				r.MeasureSubscriberSubscribeOpDuration(context.TODO(), "t2", "op2", false, 143*time.Millisecond)
+			},
+			expMetrics: []string{
+				`# HELP rollify_subscriber_subscribe_duration_seconds The duration of subscriber subscribe operations.`,
+				`# TYPE rollify_subscriber_subscribe_duration_seconds histogram`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.005"} 0`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.01"} 0`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.025"} 0`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.05"} 0`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.1"} 2`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.25"} 2`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.5"} 2`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="1"} 2`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="2.5"} 2`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="5"} 2`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="10"} 3`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="+Inf"} 3`,
+				`rollify_subscriber_subscribe_duration_seconds_count{subscriber_type="t1",subscription="op1",success="true"} 3`,
+
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.005"} 0`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.01"} 0`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.025"} 0`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.05"} 0`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.1"} 0`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.25"} 1`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.5"} 1`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="1"} 1`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="2.5"} 1`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="5"} 1`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="10"} 1`,
+				`rollify_subscriber_subscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="+Inf"} 1`,
+				`rollify_subscriber_subscribe_duration_seconds_count{subscriber_type="t2",subscription="op2",success="false"} 1`,
+			},
+		},
+
+		"Measure subscriber unsubscribe duration.": {
+			measure: func(r metrics.Recorder) {
+				r.MeasureSubscriberUnsubscribeOpDuration(context.TODO(), "t1", "op1", true, 55*time.Millisecond)
+				r.MeasureSubscriberUnsubscribeOpDuration(context.TODO(), "t1", "op1", true, 55*time.Millisecond)
+				r.MeasureSubscriberUnsubscribeOpDuration(context.TODO(), "t1", "op1", true, 6*time.Second)
+				r.MeasureSubscriberUnsubscribeOpDuration(context.TODO(), "t2", "op2", false, 143*time.Millisecond)
+			},
+			expMetrics: []string{
+				`# HELP rollify_subscriber_unsubscribe_duration_seconds The duration of subscriber unsubscribe operations.`,
+				`# TYPE rollify_subscriber_unsubscribe_duration_seconds histogram`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.005"} 0`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.01"} 0`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.025"} 0`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.05"} 0`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.1"} 2`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.25"} 2`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.5"} 2`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="1"} 2`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="2.5"} 2`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="5"} 2`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="10"} 3`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="+Inf"} 3`,
+				`rollify_subscriber_unsubscribe_duration_seconds_count{subscriber_type="t1",subscription="op1",success="true"} 3`,
+
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.005"} 0`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.01"} 0`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.025"} 0`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.05"} 0`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.1"} 0`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.25"} 1`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.5"} 1`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="1"} 1`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="2.5"} 1`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="5"} 1`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="10"} 1`,
+				`rollify_subscriber_unsubscribe_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="+Inf"} 1`,
+				`rollify_subscriber_unsubscribe_duration_seconds_count{subscriber_type="t2",subscription="op2",success="false"} 1`,
+			},
+		},
+
+		"Measure subscriber event handler duration.": {
+			measure: func(r metrics.Recorder) {
+				r.MeasureSubscriberEventHandleOpDuration(context.TODO(), "t1", "op1", true, 55*time.Millisecond)
+				r.MeasureSubscriberEventHandleOpDuration(context.TODO(), "t1", "op1", true, 55*time.Millisecond)
+				r.MeasureSubscriberEventHandleOpDuration(context.TODO(), "t1", "op1", true, 6*time.Second)
+				r.MeasureSubscriberEventHandleOpDuration(context.TODO(), "t2", "op2", false, 143*time.Millisecond)
+			},
+			expMetrics: []string{
+				`# HELP rollify_subscriber_event_handler_duration_seconds The duration of subscriber event handler execution.`,
+				`# TYPE rollify_subscriber_event_handler_duration_seconds histogram`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.005"} 0`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.01"} 0`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.025"} 0`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.05"} 0`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.1"} 2`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.25"} 2`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="0.5"} 2`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="1"} 2`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="2.5"} 2`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="5"} 2`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="10"} 3`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t1",subscription="op1",success="true",le="+Inf"} 3`,
+				`rollify_subscriber_event_handler_duration_seconds_count{subscriber_type="t1",subscription="op1",success="true"} 3`,
+
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.005"} 0`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.01"} 0`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.025"} 0`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.05"} 0`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.1"} 0`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.25"} 1`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="0.5"} 1`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="1"} 1`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="2.5"} 1`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="5"} 1`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="10"} 1`,
+				`rollify_subscriber_event_handler_duration_seconds_bucket{subscriber_type="t2",subscription="op2",success="false",le="+Inf"} 1`,
+				`rollify_subscriber_event_handler_duration_seconds_count{subscriber_type="t2",subscription="op2",success="false"} 1`,
+			},
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This PR adds metrics for the event subscribers.

- Metrics quantity and duration for subscriptions.
- Metrics quantity and duration for unsubscriptions.
- Metrics quantity and duration for event handlings.